### PR TITLE
fix app labels

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -4,19 +4,19 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
   namespace: showks
   labels:
-    app: {{ .Chart.Name }}
+    app: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}
+      app: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}
+        app: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}-{{ .Values.userID }}
+        - name: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
           image: containerdaysjp/{{ .Chart.Name }}-{{ .Values.userID }}:{{ .Values.image.tag }}
           ports:
             - name: app-port

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,23 +1,23 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Chart.Name }}{{ .Values.nameSuffix }}
+  name: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
   namespace: showks
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: {{ .Chart.Name }}.stg.showks.containerdays.jp
+  - host: {{ .Chart.Name }}-{{ .Values.userID }}.stg.showks.containerdays.jp
     http:
       paths:
       - path: /
         backend:
-          serviceName: {{ .Chart.Name }}{{ .Values.nameSuffix }}
+          serviceName: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
           servicePort: 8080
-  - host: {{ .Chart.Name }}.prod.showks.containerdays.jp
+  - host: {{ .Chart.Name }}-{{ .Values.userID }}.prod.showks.containerdays.jp
     http:
       paths:
       - path: /
         backend:
-          serviceName: {{ .Chart.Name }}{{ .Values.nameSuffix }}
+          serviceName: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
           servicePort: 8080

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
   namespace: showks
   labels:
-    app: {{ .Chart.Name }}
+    app: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}
 spec:
   type: ClusterIP
   ports:
@@ -13,5 +13,4 @@ spec:
       protocol: TCP
       name: app-port
   selector:
-    app: {{ .Chart.Name }}
-
+    app: {{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}


### PR DESCRIPTION
tempつくやつとつかないやつが、おなじnamespace内でそれぞれservice⇔podを紐付けるためのselectorとしてlabels{app}を使うので、 `{{ .Chart.Name }}-{{ .Values.userID }}{{ .Values.nameSuffix }}` という形式になっていなければならない気がします